### PR TITLE
server.pidをコンテナ起動時に削除するスクリプトを追加

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,5 +23,9 @@ RUN gem install bundler && \
 # その他のプロジェクトファイルをコピー
 COPY . /app
 
+COPY entrypoint.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/entrypoint.sh
+ENTRYPOINT ["entrypoint.sh"]
+
 # コマンドの実行
 CMD ["rails", "server", "-b", "0.0.0.0", "-p", "3000"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+rm -f /app/tmp/pids/server.pid
+
+exec "$@"


### PR DESCRIPTION
`server.pid` ファイルは、Railsサーバーが起動したときに作成される プロセスIDを記録するファイル。

サーバーが強制終了されたり、異常終了した場合、`server.pid` が削除されずに残ることがある。

この状態で再びRailsサーバーを起動しようとするとエラーになる。

そのため、Dockerコンテナ起動時に`server.pid`を削除するシェルスクリプトを追加しました。