### PR TITLE
Feat/review access restriction(#86)

### DIFF
--- a/app/controllers/api/v1/auth_controller.rb
+++ b/app/controllers/api/v1/auth_controller.rb
@@ -61,7 +61,8 @@ class Api::V1::AuthController < ApplicationController
           id: current_user.id,
           email: current_user.email,
           name: current_user.name,
-          avatar_url: current_user.avatar_url
+          avatar_url: current_user.avatar_url,
+          reviews_count: current_user.reviews_count
         }
       }, status: :ok
     else

--- a/app/controllers/api/v1/review_periods_controller.rb
+++ b/app/controllers/api/v1/review_periods_controller.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class ReviewPeriodsController < ApplicationController
+      include Authenticatable
+      before_action :authenticate_request
+      before_action :require_admin_privileges
+      before_action :set_review_period, only: [:show, :update, :destroy, :activate, :deactivate]
+
+      def index
+        periods = ReviewPeriod.all.order(:start_date)
+        render json: periods.as_json(
+          only: [:id, :period_name, :start_date, :end_date, :is_active, :created_at, :updated_at],
+          methods: [:within_period?]
+        )
+      end
+
+      def show
+        period_data = @review_period.as_json(
+          only: [:id, :period_name, :start_date, :end_date, :is_active, :created_at, :updated_at],
+          methods: [:within_period?]
+        )
+        period_data[:user_count] = @review_period.user_review_period_counts.count
+        period_data[:total_reviews] = @review_period.user_review_period_counts.sum(:reviews_count)
+        
+        render json: period_data
+      end
+
+      def create
+        @review_period = ReviewPeriod.new(review_period_params)
+        
+        if @review_period.save
+          render json: @review_period.as_json(
+            only: [:id, :period_name, :start_date, :end_date, :is_active, :created_at, :updated_at]
+          ), status: :created
+        else
+          render json: { errors: @review_period.errors.full_messages }, status: :unprocessable_entity
+        end
+      end
+
+      def update
+        if @review_period.update(review_period_params)
+          render json: @review_period.as_json(
+            only: [:id, :period_name, :start_date, :end_date, :is_active, :created_at, :updated_at]
+          )
+        else
+          render json: { errors: @review_period.errors.full_messages }, status: :unprocessable_entity
+        end
+      end
+
+      def destroy
+        if @review_period.destroy
+          render json: { message: '期間を削除しました' }
+        else
+          render json: { errors: @review_period.errors.full_messages }, status: :unprocessable_entity
+        end
+      end
+
+      def activate
+        if @review_period.activate!
+          render json: { 
+            message: "期間 '#{@review_period.period_name}' をアクティブにしました",
+            period: @review_period.as_json(only: [:id, :period_name, :is_active])
+          }
+        else
+          render json: { errors: @review_period.errors.full_messages }, status: :unprocessable_entity
+        end
+      end
+
+      def deactivate
+        if @review_period.deactivate!
+          render json: { 
+            message: "期間 '#{@review_period.period_name}' を無効にしました",
+            period: @review_period.as_json(only: [:id, :period_name, :is_active])
+          }
+        else
+          render json: { errors: @review_period.errors.full_messages }, status: :unprocessable_entity
+        end
+      end
+
+      def current
+        current_period = ReviewPeriod.current_period
+        if current_period
+          period_data = current_period.as_json(
+            only: [:id, :period_name, :start_date, :end_date, :is_active, :created_at, :updated_at],
+            methods: [:within_period?]
+          )
+          period_data[:user_count] = current_period.user_review_period_counts.count
+          period_data[:total_reviews] = current_period.user_review_period_counts.sum(:reviews_count)
+          
+          render json: period_data
+        else
+          render json: { message: '現在アクティブな期間はありません' }, status: :not_found
+        end
+      end
+
+      private
+
+      def set_review_period
+        @review_period = ReviewPeriod.find(params[:id])
+      rescue ActiveRecord::RecordNotFound
+        render json: { error: '期間が見つかりません' }, status: :not_found
+      end
+
+      def review_period_params
+        params.require(:review_period).permit(:period_name, :start_date, :end_date, :is_active)
+      end
+
+      def require_admin_privileges
+        # TODO: 実際の管理者権限チェックを実装
+        # 現在は仮実装として認証済みユーザーのみ許可
+        unless current_user
+          render json: { error: '管理者権限が必要です' }, status: :forbidden
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/reviews_controller.rb
+++ b/app/controllers/api/v1/reviews_controller.rb
@@ -4,7 +4,8 @@ module Api
   module V1
     class ReviewsController < ApplicationController
       include Authenticatable
-      skip_before_action :authenticate_request, only: %i[index total latest]
+      skip_before_action :authenticate_request, only: %i[index create total latest]
+      before_action :authenticate_optional, only: [:index]
       before_action :authenticate_optional_for_create, only: [:create]
       before_action :set_lecture, except: %i[total latest update destroy]
 
@@ -14,6 +15,11 @@ module Api
         @review.user = current_user if current_user
         
         if @review.save
+          # レビュー投稿成功時、期間別レビュー数を更新（ログインユーザーの場合のみ）
+          if current_user
+            current_user.increment_period_review_count!
+          end
+          
           review_data = @review.as_json(include: { user: { only: %i[id name avatar_url] } })
           review_data['user_id'] = @review.user_id
           render json: { 
@@ -27,14 +33,33 @@ module Api
 
       def index
         reviews = @lecture.reviews.includes(:user, :thanks)
-        reviews_json = reviews.map do |review|
-          review_data = review.as_json
-          review_data['user_id'] = review.user_id
-          review_data['user'] = review.user ? review.user.as_json(only: %i[id name avatar_url]) : { id: nil, name: '匿名ユーザー', avatar_url: nil }
-          review_data['thanks_count'] = review.thanks.count
-          review_data
+        
+        # レビュー閲覧権限をチェック
+        if has_review_access?
+          # 権限がある場合：完全なレビューデータを返す
+          reviews_json = reviews.map do |review|
+            review_data = review.as_json
+            review_data['user_id'] = review.user_id
+            review_data['user'] = review.user ? review.user.as_json(only: %i[id name avatar_url]) : { id: nil, name: '匿名ユーザー', avatar_url: nil }
+            review_data['thanks_count'] = review.thanks.count
+            review_data['access_granted'] = true
+            review_data
+          end
+          render json: reviews_json
+        else
+          # 権限がない場合：部分的なレビューデータを返す（コメントを制限）
+          reviews_json = reviews.map do |review|
+            review_data = review.as_json
+            review_data['user_id'] = review.user_id
+            review_data['user'] = review.user ? review.user.as_json(only: %i[id name avatar_url]) : { id: nil, name: '匿名ユーザー', avatar_url: nil }
+            review_data['thanks_count'] = review.thanks.count
+            review_data['access_granted'] = false
+            # コメントは部分的にマスク（フロントエンドでの処理と一致させる）
+            review_data['content'] = mask_review_content(review.content) if review.content.present?
+            review_data
+          end
+          render json: reviews_json
         end
-        render json: reviews_json
       end
 
       def total
@@ -73,6 +98,8 @@ module Api
         end
         
         if @review.destroy
+          # レビュー削除時、期間別レビュー数を減少
+          current_user.decrement_period_review_count!
           render json: { success: true, message: 'レビューを削除しました' }
         else
           render json: { success: false, message: 'レビューの削除に失敗しました' }, status: :unprocessable_entity
@@ -96,9 +123,6 @@ module Api
 
       private
 
-      def authenticate_optional_for_create
-        authenticate_optional
-      end
 
       def set_lecture
         @lecture = Lecture.find(params[:lecture_id])
@@ -107,6 +131,59 @@ module Api
       def review_params
         params.require(:review).permit(:rating, :content, :period_year, :period_term, :textbook, :attendance,
                                        :grading_type, :content_difficulty, :content_quality)
+      end
+
+      # レビュー閲覧権限をチェック（期間ベース対応）
+      def has_review_access?
+        Rails.logger.info "=== PERIOD-BASED REVIEW ACCESS CHECK ==="
+        Rails.logger.info "Current user: #{current_user&.id}"
+        
+        return false unless current_user
+        
+        # 現在の期間を取得
+        current_period = ReviewPeriod.current_period
+        if current_period
+          # 期間ベースの権限チェック
+          period_reviews_count = current_user.reviews_count_for_period(current_period)
+          Rails.logger.info "Period: #{current_period.period_name}"
+          Rails.logger.info "Period reviews count: #{period_reviews_count}"
+          
+          if period_reviews_count >= 1
+            Rails.logger.info "✅ Access granted: User has #{period_reviews_count} reviews in current period"
+            return true
+          end
+        else
+          # 期間が設定されていない場合は従来の全体レビュー数ベースで判定
+          Rails.logger.info "No active period found, using global reviews count: #{current_user.reviews_count}"
+          if current_user.reviews_count >= 1
+            Rails.logger.info "✅ Access granted: User has #{current_user.reviews_count} total reviews"
+            return true
+          end
+        end
+        
+        Rails.logger.info "❌ Access denied: Insufficient reviews for current period"
+        false
+      end
+
+      # レビューコンテンツを部分的にマスク
+      def mask_review_content(content)
+        return nil if content.blank?
+        
+        # 短いコメントの場合（50文字以下）は30%まで表示
+        if content.length <= 50
+          visible_length = (content.length * 0.3).floor
+          content[0, visible_length] + "..." if visible_length > 0
+        else
+          # 長いコメントの場合は1行目の半分まで表示
+          first_line_end = content.index("\n") || [content.length, 80].min
+          first_line = content[0, first_line_end]
+          visible_length = (first_line.length * 0.5).floor
+          if visible_length > 0
+            content[0, visible_length] + "..."
+          else
+            "..."
+          end
+        end
       end
 
     end

--- a/app/controllers/concerns/authenticatable.rb
+++ b/app/controllers/concerns/authenticatable.rb
@@ -25,4 +25,8 @@ module Authenticatable
     result = AuthorizeApiRequest.call(request.headers)
     @current_user = result[:result]
   end
+
+  def authenticate_optional_for_create
+    authenticate_optional
+  end
 end

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -2,8 +2,24 @@
 
 class Review < ApplicationRecord
   belongs_to :lecture
-  belongs_to :user, optional: true, counter_cache: :reviews_count # 既存データとの互換性のため一時的にoptional、カウンターキャッシュ追加
+  belongs_to :user, optional: true
   has_many :thanks, dependent: :destroy
 
+  validates :rating, presence: true
+  validates :content, presence: true, length: { minimum: 20, maximum: 400, too_short: "は%{count}文字以上で入力してください" }
+
   validates :user_id, uniqueness: { scope: :lecture_id, allow_nil: true, message: 'は同じ講義に複数のレビューを投稿できません' }
+
+  after_create :increment_user_reviews_count
+  after_destroy :decrement_user_reviews_count
+
+  private
+
+  def increment_user_reviews_count
+    user&.increment!(:reviews_count)
+  end
+
+  def decrement_user_reviews_count
+    user&.decrement!(:reviews_count)
+  end
 end

--- a/app/models/review_period.rb
+++ b/app/models/review_period.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+class ReviewPeriod < ApplicationRecord
+  has_many :user_review_period_counts, dependent: :destroy
+  has_many :users, through: :user_review_period_counts
+
+  validates :period_name, presence: true, uniqueness: true
+  validates :start_date, presence: true
+  validates :end_date, presence: true
+  validate :end_date_after_start_date
+  validate :only_one_active_period
+
+  scope :active, -> { where(is_active: true) }
+  scope :inactive, -> { where(is_active: false) }
+  scope :current, -> { where('start_date <= ? AND end_date >= ?', Time.current, Time.current) }
+
+  def self.current_period
+    active.first
+  end
+
+  def activate!
+    ActiveRecord::Base.transaction do
+      # 現在のアクティブな期間を無効にする
+      ReviewPeriod.where(is_active: true).update_all(is_active: false)
+      # この期間をアクティブにする
+      update!(is_active: true)
+    end
+  end
+
+  def deactivate!
+    update!(is_active: false)
+  end
+
+  def within_period?(datetime = Time.current)
+    start_date <= datetime && datetime <= end_date
+  end
+
+  def user_reviews_count(user)
+    user_review_period_counts.find_by(user: user)&.reviews_count || 0
+  end
+
+  def increment_user_reviews_count!(user)
+    count_record = user_review_period_counts.find_or_initialize_by(user: user)
+    count_record.reviews_count = (count_record.reviews_count || 0) + 1
+    count_record.save!
+    count_record.reviews_count
+  end
+
+  private
+
+  def end_date_after_start_date
+    return unless start_date && end_date
+    
+    if end_date <= start_date
+      errors.add(:end_date, 'must be after start date')
+    end
+  end
+
+  def only_one_active_period
+    return unless is_active
+
+    existing_active = ReviewPeriod.where(is_active: true)
+    existing_active = existing_active.where.not(id: id) if persisted?
+    
+    if existing_active.exists?
+      errors.add(:is_active, 'only one period can be active at a time')
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,8 @@ class User < ApplicationRecord
   has_many :reviews, dependent: :destroy
   has_many :thanks, dependent: :destroy
   has_many :bookmarks, dependent: :destroy
+  has_many :user_review_period_counts, dependent: :destroy
+  has_many :review_periods, through: :user_review_period_counts
 
   validates :email, presence: true, uniqueness: true
   validates :name, presence: true
@@ -50,7 +52,7 @@ class User < ApplicationRecord
   # JWT用のペイロード作成
   def jwt_payload
     {
-      id: id,
+      user_id: id,
       email: email,
       name: name,
       avatar_url: avatar_url
@@ -60,5 +62,50 @@ class User < ApplicationRecord
   # アバター画像のURLを取得（デフォルト画像対応）
   def avatar_image_url
     avatar_url.present? ? avatar_url : nil
+  end
+
+  # 現在の期間での投稿レビュー数を取得
+  def reviews_count_for_period(period = nil)
+    period ||= ReviewPeriod.current_period
+    return 0 unless period
+    
+    user_review_period_counts.find_by(review_period: period)&.reviews_count || 0
+  end
+
+  # 現在の期間でレビューアクセス権限があるかチェック
+  def has_review_access_for_period?(period = nil)
+    reviews_count_for_period(period) >= 1
+  end
+
+  # レビュー投稿時に期間別カウントを増加
+  def increment_period_review_count!(period = nil)
+    period ||= ReviewPeriod.current_period
+    return unless period
+    
+    count_record = user_review_period_counts.find_or_initialize_by(review_period: period)
+    count_record.reviews_count = (count_record.reviews_count || 0) + 1
+    count_record.save!
+    
+    # 全体のレビュー数も更新
+    increment!(:reviews_count)
+    
+    count_record.reviews_count
+  end
+
+  # レビュー削除時に期間別カウントを減少
+  def decrement_period_review_count!(period = nil)
+    period ||= ReviewPeriod.current_period
+    return unless period
+    
+    count_record = user_review_period_counts.find_by(review_period: period)
+    return unless count_record && count_record.reviews_count > 0
+    
+    count_record.reviews_count -= 1
+    count_record.save!
+    
+    # 全体のレビュー数も更新
+    decrement!(:reviews_count) if reviews_count > 0
+    
+    count_record.reviews_count
   end
 end

--- a/app/models/user_review_period_count.rb
+++ b/app/models/user_review_period_count.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class UserReviewPeriodCount < ApplicationRecord
+  belongs_to :user
+  belongs_to :review_period
+
+  validates :reviews_count, presence: true, numericality: { greater_than_or_equal_to: 0 }
+  validates :user_id, uniqueness: { scope: :review_period_id }
+
+  scope :for_period, ->(period) { where(review_period: period) }
+  scope :for_user, ->(user) { where(user: user) }
+
+  def increment!
+    increment(:reviews_count)
+    save!
+  end
+
+  def decrement!
+    return if reviews_count <= 0
+    
+    decrement(:reviews_count)
+    save!
+  end
+end

--- a/app/services/authorize_api_request.rb
+++ b/app/services/authorize_api_request.rb
@@ -18,7 +18,7 @@ class AuthorizeApiRequest
   attr_reader :headers
 
   def user
-    @user ||= User.find(decoded_auth_token[:id]) if decoded_auth_token
+    @user ||= User.find(decoded_auth_token[:user_id]) if decoded_auth_token
   rescue ActiveRecord::RecordNotFound
     nil
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,6 +28,17 @@ Rails.application.routes.draw do
       get '/reviews/total', to: 'reviews#total'
       get '/reviews/latest', to: 'reviews#latest'
       
+      # レビュー期間管理
+      resources :review_periods do
+        member do
+          patch :activate
+          patch :deactivate
+        end
+        collection do
+          get :current
+        end
+      end
+      
       # マイページ
       get '/mypage', to: 'mypage#show'
       get '/mypage/reviews', to: 'mypage#reviews'

--- a/db/migrate/20250821074834_create_review_periods.rb
+++ b/db/migrate/20250821074834_create_review_periods.rb
@@ -1,0 +1,16 @@
+class CreateReviewPeriods < ActiveRecord::Migration[7.0]
+  def change
+    create_table :review_periods do |t|
+      t.string :period_name, null: false, comment: '期間名 (例: 2025-spring)'
+      t.datetime :start_date, null: false, comment: '期間開始日'
+      t.datetime :end_date, null: false, comment: '期間終了日'
+      t.boolean :is_active, default: false, null: false, comment: '現在有効な期間かを示すフラグ'
+
+      t.timestamps
+    end
+
+    add_index :review_periods, :period_name, unique: true
+    add_index :review_periods, :is_active
+    add_index :review_periods, [:start_date, :end_date]
+  end
+end

--- a/db/migrate/20250821074843_create_user_review_period_counts.rb
+++ b/db/migrate/20250821074843_create_user_review_period_counts.rb
@@ -1,0 +1,13 @@
+class CreateUserReviewPeriodCounts < ActiveRecord::Migration[7.0]
+  def change
+    create_table :user_review_period_counts do |t|
+      t.references :user, null: false, foreign_key: true, comment: 'ユーザーID'
+      t.references :review_period, null: false, foreign_key: true, comment: 'レビュー期間ID'
+      t.integer :reviews_count, default: 0, null: false, comment: '期間内のレビュー投稿数'
+
+      t.timestamps
+    end
+
+    add_index :user_review_period_counts, [:user_id, :review_period_id], unique: true, name: 'index_user_period_counts_unique'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_07_07_153022) do
+ActiveRecord::Schema[7.0].define(version: 2025_08_21_074843) do
   create_table "bookmarks", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "user_id"
     t.bigint "lecture_id"
@@ -33,6 +33,18 @@ ActiveRecord::Schema[7.0].define(version: 2025_07_07_153022) do
     t.index ["title"], name: "index_lectures_on_title"
   end
 
+  create_table "review_periods", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "period_name", null: false, comment: "期間名 (例: 2025-spring)"
+    t.datetime "start_date", null: false, comment: "期間開始日"
+    t.datetime "end_date", null: false, comment: "期間終了日"
+    t.boolean "is_active", default: false, null: false, comment: "現在有効な期間かを示すフラグ"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["is_active"], name: "index_review_periods_on_is_active"
+    t.index ["period_name"], name: "index_review_periods_on_period_name", unique: true
+    t.index ["start_date", "end_date"], name: "index_review_periods_on_start_date_and_end_date"
+  end
+
   create_table "reviews", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.float "rating"
     t.text "content"
@@ -48,6 +60,9 @@ ActiveRecord::Schema[7.0].define(version: 2025_07_07_153022) do
     t.datetime "updated_at", null: false
     t.bigint "user_id"
     t.integer "thanks_count", default: 0, null: false
+    t.index ["lecture_id", "content_difficulty"], name: "index_reviews_on_lecture_id_and_content_difficulty"
+    t.index ["lecture_id", "content_quality"], name: "index_reviews_on_lecture_id_and_content_quality"
+    t.index ["lecture_id", "period_year"], name: "index_reviews_on_lecture_id_and_period_year"
     t.index ["lecture_id"], name: "index_reviews_on_lecture_id"
     t.index ["user_id"], name: "index_reviews_on_user_id"
   end
@@ -60,6 +75,17 @@ ActiveRecord::Schema[7.0].define(version: 2025_07_07_153022) do
     t.index ["review_id"], name: "index_thanks_on_review_id"
     t.index ["user_id", "review_id"], name: "index_thanks_on_user_id_and_review_id", unique: true
     t.index ["user_id"], name: "index_thanks_on_user_id"
+  end
+
+  create_table "user_review_period_counts", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "user_id", null: false, comment: "ユーザーID"
+    t.bigint "review_period_id", null: false, comment: "レビュー期間ID"
+    t.integer "reviews_count", default: 0, null: false, comment: "期間内のレビュー投稿数"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["review_period_id"], name: "index_user_review_period_counts_on_review_period_id"
+    t.index ["user_id", "review_period_id"], name: "index_user_period_counts_unique", unique: true
+    t.index ["user_id"], name: "index_user_review_period_counts_on_user_id"
   end
 
   create_table "users", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
@@ -80,4 +106,6 @@ ActiveRecord::Schema[7.0].define(version: 2025_07_07_153022) do
   add_foreign_key "reviews", "users"
   add_foreign_key "thanks", "reviews"
   add_foreign_key "thanks", "users"
+  add_foreign_key "user_review_period_counts", "review_periods"
+  add_foreign_key "user_review_period_counts", "users"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,62 +1,37 @@
 # frozen_string_literal: true
 
-# # フェイカーを使用してランダムデータを生成します
-# require 'faker'
 
-# Faker::Config.locale = :ja
+# テスト用講義の手動作成
+puts "テスト用講義を作成しています..."
 
-# # 学部のオプション
-# faculties = ['G: 教養科目', 'H: 人文学部', 'K: 教育学部', 'L: 法学部', 'E: 経済科学部',
-#              'S: 理学部', 'M: 医学部', 'D:】＿？＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿_________________________ 歯学部', 'T: 工学部', 'A: 農学部', 'X: 創生学部']
+test_lectures = [
+  { title: 'プログラミング基礎', lecturer: '田中 太郎', faculty: 'T: 工学部' },
+  { title: 'データベース設計', lecturer: '佐藤 花子', faculty: 'T: 工学部' },
+  { title: 'Web開発入門', lecturer: '山田 次郎', faculty: 'T: 工学部' },
+  { title: '情報セキュリティ', lecturer: '鈴木 三郎', faculty: 'T: 工学部' },
+  { title: 'システム設計論', lecturer: '高橋 四郎', faculty: 'T: 工学部' },
+  { title: 'アルゴリズム入門', lecturer: '伊藤 五郎', faculty: 'T: 工学部' },
+  { title: 'コンピュータネットワーク', lecturer: '渡辺 六郎', faculty: 'T: 工学部' },
+  { title: 'ソフトウェア工学', lecturer: '中村 七子', faculty: 'T: 工学部' },
+  { title: '人工知能概論', lecturer: '小林 八郎', faculty: 'T: 工学部' },
+  { title: 'マルチメディア処理', lecturer: '加藤 九子', faculty: 'T: 工学部' }
+]
 
-# # 講義名のオプション
-# lecture_titles = [
-#   '微積分学Ⅰ', '物理学概論', '情報科学入門', '統計学基礎', '線形代数学', '現代日本語', '経済数学', '日本文学Ⅰ', '科学基礎A',
-#   '生物学入門', '現代社会理論', '応用倫理学', '経済政策', '宇宙論', '生態学', 'プログラミング基礎', 'データサイエンス',
-#   '化学原理', '量子力学', '日本史概観', '心理学入門', '生命科学', '電気電子工学', '有機化学', 'ビジネス英語',
-#   'データベース基礎', '地球環境学', '神経科学', 'オペレーションズ・リサーチ', 'マクロ経済学', 'ミクロ経済学',
-#   '言語学入門', 'コンピュータアーキテクチャ', 'アルゴリズム理論', '微分方程式', '生化学', '統計力学',
-#   '日本経済論', '数理統計学', '民法概説', '物質科学'
-# ]
+test_lectures.each do |lecture_data|
+  lecture = Lecture.find_or_create_by(
+    title: lecture_data[:title],
+    lecturer: lecture_data[:lecturer],
+    faculty: lecture_data[:faculty]
+  )
+  
+  if lecture.persisted?
+    puts "✅ 講義作成: #{lecture.title} (#{lecture.lecturer})"
+  else
+    puts "❌ 講義作成失敗: #{lecture_data[:title]} - エラー: #{lecture.errors.full_messages.join(', ')}"
+  end
+end
 
-# # レビューのコメントのオプション
-# review_comments = ['授業はわかりやすかった。', '難しい内容だったが、教授の説明が上手い。', '試験が難しかった。', '自習が必要な授業。', '参考書があると理解しやすい。']
-
-# # レビューの各属性のオプション
-# period_years = %w[2023 2022 2021 2020]
-# period_terms = ['1ターム', '2ターム', '1, 2ターム', '3ターム', '4ターム', '3, 4ターム']
-# textbooks = %w[必要 不要]
-# attendances = %w[毎回確認 たまに確認 なし]
-# grading_types = ['テストのみ', 'レポートのみ', 'テスト,レポート', 'その他']
-# content_difficulties = %w[とても楽 楽 普通 難しい とても難しい]
-# content_qualities = %w[とても良い 良い 普通 悪い とても悪い]
-
-# 200.times do |_i|
-#   lecture_title = lecture_titles.sample
-
-#   lecture = Lecture.create!(
-#     title: lecture_title,
-#     lecturer: Faker::Name.name,
-#     faculty: faculties.sample
-#   )
-
-#   # 各講義に対して2つのレビューを生成します
-#   2.times do
-#     Review.create!(
-#       rating: rand(1..5),
-#       period_year: period_years.sample,
-#       period_term: period_terms.sample,
-#       textbook: textbooks.sample,
-#       attendance: attendances.sample,
-#       grading_type: grading_types.sample,
-#       content_difficulty: content_difficulties.sample,
-#       content_quality: content_qualities.sample,
-#       content: review_comments.sample,
-#       lecture_id: lecture.id
-#     )
-#   end
-# end
-
+puts "テスト用講義の作成完了\n"
 
 require 'csv'
 require 'activerecord-import'


### PR DESCRIPTION
レビュー閲覧制限

- 匿名ユーザー
    - ログインし、1レビューしないと閲覧できない
    - レビューの投稿は可能
- ログインしているが、レビューはしていないユーザー
    - 1レビューしないと閲覧できない
    - レビューの投稿は可能
- ログインしていて、1つでもレビューをしたユーザー
    - 全てのレビューの閲覧が可能
    - レビューの投稿は可能
- データベースのセッションテーブルで制限を設ける
    - cookie削除や、デバイスを変えてもユーザーのステータスが変わらないようにする
    - 将来的には以下のようなreview_periodsテーブルで管理者が切り替えることによって履修期間ごとに閲覧制限をリセットできるようにする。これによってさらにレビューを投稿するユーザーが増えるため。