### PR TITLE
fix: シードが最新年度の講義CSVを参照するよう修正

### DIFF
--- a/app/services/lecture_data_csv_selector.rb
+++ b/app/services/lecture_data_csv_selector.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class LectureDataCsvSelector
+  YEARLY_CSV_PATTERN = /^lectureData_(\d{4})\.csv$/
+
+  class << self
+    def latest_path(root: Rails.root)
+      latest_yearly_path(root) || root.join('lectureData.csv')
+    end
+
+    private
+
+    def latest_yearly_path(root)
+      yearly_files = Dir[root.join('lectureData_*.csv')].filter_map do |path|
+        match = File.basename(path).match(YEARLY_CSV_PATTERN)
+        [match[1].to_i, Pathname.new(path)] if match
+      end
+
+      yearly_files.max_by(&:first)&.last
+    end
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -36,10 +36,19 @@ puts "テスト用講義の作成完了\n"
 require 'csv'
 require 'activerecord-import'
 
-csv_file_path = Rails.root.join('lectureData_2025.csv')
+csv_file_path = LectureDataCsvSelector.latest_path
 
 puts "Seeding lectures from #{File.basename(csv_file_path)}..."
 puts "重複する講義は無視され、既存データは削除されません。"
+
+selected_year = File.basename(csv_file_path)[/^lectureData_(\d{4})\.csv$/, 1]&.to_i
+current_year = Date.current.year
+
+if selected_year && selected_year < current_year
+  puts "警告: 現在は #{current_year} 年ですが、最新の講義CSVは #{selected_year} 年度です。#{current_year} 年度のCSV未投入の可能性があります。"
+elsif selected_year.nil? && File.basename(csv_file_path) == 'lectureData.csv'
+  puts '警告: 年度付き lectureData_YYYY.csv が見つからないため lectureData.csv を使用します。'
+end
 
 unless File.exist?(csv_file_path)
   puts "エラー: CSVファイルが見つかりません: #{csv_file_path}"

--- a/lib/tasks/demo.rake
+++ b/lib/tasks/demo.rake
@@ -4,6 +4,7 @@ namespace :demo do
   desc 'review access 確認用のデモデータを投入する'
   task review_access_seed: :environment do
     ActiveRecord::Base.transaction do
+      current_year = Date.current.year.to_s
       setting = SiteSetting.current!
       setting.update!(lecture_review_restriction_enabled: false, last_updated_by: nil)
 
@@ -56,7 +57,7 @@ namespace :demo do
       Review.find_or_initialize_by(lecture: one_review_lecture, user: unlocked_user).tap do |review|
         review.rating = 5
         review.content = 'レビュー投稿済みユーザーの確認用レビューです。reviews_count が 1 以上になることを確認するための本文です。'
-        review.period_year = '2025'
+        review.period_year = current_year
         review.period_term = '1ターム'
         review.save!
       end
@@ -64,7 +65,7 @@ namespace :demo do
       Review.find_or_initialize_by(lecture: two_review_lecture, user: helper_user).tap do |review|
         review.rating = 4
         review.content = '2件授業の1件目レビューです。閲覧制限ON時でも全文表示される想定の本文です。'
-        review.period_year = '2025'
+        review.period_year = current_year
         review.period_term = '1ターム'
         review.save!
       end
@@ -72,7 +73,7 @@ namespace :demo do
       Review.find_or_initialize_by(lecture: two_review_lecture, user: admin_user).tap do |review|
         review.rating = 3
         review.content = '2件授業の2件目レビューです。閲覧制限ON時には先頭30文字だけ返ることを確認するための本文です。'
-        review.period_year = '2025'
+        review.period_year = current_year
         review.period_term = '2ターム'
         review.save!
       end

--- a/spec/services/lecture_data_csv_selector_spec.rb
+++ b/spec/services/lecture_data_csv_selector_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'tmpdir'
+
+RSpec.describe LectureDataCsvSelector do
+  describe '.latest_path' do
+    it 'returns the latest yearly lecture data csv when multiple yearly files exist' do
+      Dir.mktmpdir do |dir|
+        root = Pathname.new(dir)
+        root.join('lectureData_2024.csv').write('')
+        root.join('lectureData_2026.csv').write('')
+        root.join('lectureData_2025.csv').write('')
+
+        expect(described_class.latest_path(root: root)).to eq(root.join('lectureData_2026.csv'))
+      end
+    end
+
+    it 'falls back to lectureData.csv when no yearly csv exists' do
+      Dir.mktmpdir do |dir|
+        root = Pathname.new(dir)
+        root.join('lectureData.csv').write('')
+
+        expect(described_class.latest_path(root: root)).to eq(root.join('lectureData.csv'))
+      end
+    end
+
+    it 'ignores files that do not match the yearly csv naming pattern' do
+      Dir.mktmpdir do |dir|
+        root = Pathname.new(dir)
+        root.join('lectureData.csv').write('')
+        root.join('lectureData_latest.csv').write('')
+        root.join('lectureData_2026_backup.csv').write('')
+        root.join('lectureData_2025.csv').write('')
+
+        expect(described_class.latest_path(root: root)).to eq(root.join('lectureData_2025.csv'))
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要
- `LectureDataCsvSelector` を追加し、`lectureData_YYYY.csv` の最新年度を自動選択するように変更
- 年度付き CSV が古い、または存在しない場合に `db:seed` 実行時の警告を追加
- review access 用のデモデータが固定の `2025` ではなく現在年を使うよう修正
- 年度付き CSV の選択ロジックに service spec を追加

## 確認内容
- `docker-compose run --rm gatareview-back bundle exec rspec spec/services/lecture_data_csv_selector_spec.rb`
- `ruby -c db/seeds.rb`
- `ruby -c lib/tasks/demo.rake`