### PR TITLE
RailsレイアウトのOGP URLをwwwドメインに統一

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,8 +7,8 @@
   <meta property="og:locale" content="ja_JP">
   <meta property="og:type" content="website" />
   <meta property="og:title" content="ガタレビュ！" />
-  <meta property="og:url" content="https://gatareview.com/lectures" />
-  <meta property="og:image" content="https://gatareview.com/ogp.png" />
+  <meta property="og:url" content="https://www.gatareview.com/lectures" />
+  <meta property="og:image" content="https://www.gatareview.com/ogp.png" />
   <meta property="og:description" content="「ガタレビュ！」は新潟大学の講義レビューサイトです。シラバスではわからないリアルな情報を共有しましょう。" />
   <meta property="og:site_name" content="ガタレビュ！" />
   <meta name="color-scheme" content="light" />


### PR DESCRIPTION
## 概要

本番サイトの正規URLを `https://www.gatareview.com` として扱うため、Rails layout の OGP URL 表記を www ドメインに統一しました。

## 変更範囲

- `app/views/layouts/application.html.erb` の `og:url` を `https://www.gatareview.com/lectures` に変更
- `app/views/layouts/application.html.erb` の `og:image` を `https://www.gatareview.com/ogp.png` に変更

## 確認

- `rg -n "https://gatareview\\.com" gatareview-front/app gatareview-front/public gatareview-back/app/views/layouts/application.html.erb` で対象範囲に root ドメインの正規URL表記が残っていないことを確認
- `curl -I https://gatareview.com` で `308` により `https://www.gatareview.com/` へ転送されることを確認
- `curl -I https://www.gatareview.com` で `200` を確認
- RSpec は未実行（Rails layout の OGP URL 文字列変更のみ）

## 補足

- backend README / deploy checklist はすでに `https://www.gatareview.com` 表記だったため変更なし
- CORS の `https://gatareview.com` は root ドメイン転送・移行期間の互換性設定として変更対象外
- スクリーンショットはありません（OGPメタタグの表記変更のみ）